### PR TITLE
1.20 Port

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 org.gradle.jvmargs=-Xmx2500M
 org.gradle.daemon=false
 mapping_type=official
-mapping_version=1.19.3
-jei_version=jei-1.19.3-forge\:12.2.0.16
+mapping_version=1.20.1
+jei_version=jei-1.20.1-forge\:15.0.0.12
 mod_version=0
-artifactor_minecraft_version=1.19.3
-artifactor_forge_version=44.1.20
+artifactor_minecraft_version=1.20.1
+artifactor_forge_version=47.0.2
 artifactor_mod_version=2.0

--- a/src/main/java/tamaized/voidfog/VoidFog.java
+++ b/src/main/java/tamaized/voidfog/VoidFog.java
@@ -39,7 +39,6 @@ public class VoidFog {
 		static Config INSTANCE;
 		ForgeConfigSpec.IntValue y;
 		ForgeConfigSpec.DoubleValue distance;
-		ForgeConfigSpec.DoubleValue fade;
 		ForgeConfigSpec.BooleanValue voidscape;
 
 		ForgeConfigSpec.ConfigValue<List<? extends String>> blacklistedDims;

--- a/src/main/java/tamaized/voidfog/VoidFog.java
+++ b/src/main/java/tamaized/voidfog/VoidFog.java
@@ -2,15 +2,16 @@ package tamaized.voidfog;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.FogRenderer;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.client.event.ViewportEvent;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.MinecraftForge;
@@ -21,6 +22,8 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 
 @Mod("voidfog")
@@ -35,19 +38,35 @@ public class VoidFog {
 
 		static Config INSTANCE;
 		ForgeConfigSpec.IntValue y;
+		ForgeConfigSpec.DoubleValue distance;
+		ForgeConfigSpec.DoubleValue fade;
 		ForgeConfigSpec.BooleanValue voidscape;
+
+		ForgeConfigSpec.ConfigValue<List<? extends String>> blacklistedDims;
+		ForgeConfigSpec.BooleanValue whitelistToggle;
 
 		public Config(ForgeConfigSpec.Builder builder) {
 			y = builder.
 					translation("voidfog.config.y").
 					comment("The Y value in which void fog takes effect. (Min World Height + Y Value)").
 					defineInRange("y", 12, 0, Integer.MAX_VALUE);
+			distance = builder.
+					translation("voidfog.config.distance").
+					comment("Defines how far away the fog should be from your player. Higher numbers mean further away.").
+					defineInRange("distance", 30, 0, Double.MAX_VALUE);
 			voidscape = builder.
 					translation("voidfog.config.voidscape").
 					comment("Enable the effect everywhere in the mod Voidscape's main Dimension.").
 					define("voidscape", true);
+			blacklistedDims = builder.
+					translation("voidfog.config.blacklisted_dims").
+					comment("Defines which dimensions shouldnt render any void fog. Each entry should be a valid dimension id. For example, to blacklist void fog from appearing in Twilight Forest, add \"twilightforest:twilight_forest\" to this list.").
+					defineList("dimension_blacklist", new ArrayList<>(), s -> s instanceof String string && ResourceLocation.isValidResourceLocation(string));
+			whitelistToggle = builder.
+					translation("voidfog.config.whitelist_toggle").
+					comment("Defines whether the dimension blacklist should function as a whitelist instead, meaning that only dimensions in that config option will render void fog.").
+					define("toggle_whitelist", false);
 		}
-
 	}
 
 	public VoidFog() {
@@ -57,22 +76,17 @@ public class VoidFog {
 		Config.INSTANCE = specPair.getLeft();
 		busForge.addListener((Consumer<ViewportEvent.RenderFog>) event -> {
 			if (active || fog < 1F) {
-				float f = 3F;
+				float f = Config.INSTANCE.distance.get().floatValue();
 				f = f >= event.getFarPlaneDistance() ? event.getFarPlaneDistance() : Mth.clampedLerp(f, event.getFarPlaneDistance(), fog);
-				float shift = (float) ((active ? (fog > 0.25F ? 0.1F : 0.0005F) : (fog > 0.25F ? 0.001F : 0.0001F)) * event.getPartialTick());
+				float shift = (float) ((active ? (fog > 0.5F ? 0.005F : 0.001F) : (fog > 0.25F ? 0.01F : 0.001F)) * event.getPartialTick());
 				if (active)
 					fog -= shift;
 				else
 					fog += shift;
 				fog = Mth.clamp(fog, 0F, 1F);
 
-				if (event.getMode() == FogRenderer.FogMode.FOG_SKY) {
-					RenderSystem.setShaderFogStart(0.0F);
-					RenderSystem.setShaderFogEnd(f);
-				} else {
-					RenderSystem.setShaderFogStart(f * 0.75F);
-					RenderSystem.setShaderFogEnd(f);
-				}
+				RenderSystem.setShaderFogStart(0.0F);
+				RenderSystem.setShaderFogEnd(f);
 			}
 		});
 		busForge.addListener((Consumer<ViewportEvent.ComputeFogColor>) event -> {
@@ -83,11 +97,10 @@ public class VoidFog {
 					final float c = 0;
 					colors[i] = real == c ? c : Mth.clampedLerp(real, c, color);
 				}
-				float shift = (float) (0.1F * event.getPartialTick());
 				if (active)
-					color += shift;
+					color += (float) (0.1F * event.getPartialTick());
 				else
-					color -= shift;
+					color -= (float) (0.005F * event.getPartialTick());
 				color = Mth.clamp(color, 0F, 1F);
 				event.setRed(colors[0]);
 				event.setGreen(colors[1]);
@@ -97,13 +110,19 @@ public class VoidFog {
 		busForge.addListener((Consumer<TickEvent.PlayerTickEvent>) event -> {
 			if (event.player != Minecraft.getInstance().player)
 				return;
-			if (event.player.level != null && (event.player.getY() <= event.player.level.getMinBuildHeight() + Config.INSTANCE.y.get() || checkForVoidscapeDimension(event.player.level))) {
-				active = true;
+
+			if ((event.player.level() != null && (event.player.getY() <= event.player.level().getMinBuildHeight() + Config.INSTANCE.y.get() && Config.INSTANCE.whitelistToggle.get() == Config.INSTANCE.blacklistedDims.get().contains(event.player.level().dimension().location().toString())) || checkForVoidscapeDimension(event.player.level()))) {
+				active = !event.player.hasEffect(MobEffects.NIGHT_VISION);
 				RandomSource random = event.player.getRandom();
-				for (int i = 0; i < 15; i++) {
-					Vec3 vec = event.player.position().add(0, random.nextDouble() * 3D, 0).
-							add(new Vec3(random.nextDouble() * 6D, 0D, 0D).yRot((float) Math.toRadians(random.nextInt(360))));
-					event.player.level.addParticle(ParticleTypes.ASH, vec.x, vec.y, vec.z, 0, 0, 0);
+				for (int l = 0; l < 100; ++l) {
+					int i1 = event.player.blockPosition().getX() + random.nextInt(16) - random.nextInt(16);
+					int j1 =  event.player.blockPosition().getY() + random.nextInt(16) - random.nextInt(16);
+					int k1 =  event.player.blockPosition().getZ() + random.nextInt(16) - random.nextInt(16);
+					BlockState block = event.player.level().getBlockState(new BlockPos(i1, j1, k1));
+
+					if (block.isAir() && random.nextInt(Config.INSTANCE.y.get()) > j1) {
+						event.player.level().addParticle(ParticleTypes.ASH, i1 + random.nextFloat(), j1 + random.nextFloat(), k1 + random.nextFloat(), 0.0D, 0.0D, 0.0D);
+					}
 				}
 			} else
 				active = false;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[41,)"
+loaderVersion="[46,)"
 issueTrackerURL="https://github.com/Tamaized/Void-Fog/issues"
 license="All Rights Reserved"
 [[mods]]
@@ -13,9 +13,9 @@ displayTest="IGNORE_ALL_VERSION"
 
 '''
 
-[[dependencies.voidscape]]
+[[dependencies.voidfog]]
     modId="forge"
     mandatory=true
-    versionRange="[39.0.0,)"
+    versionRange="[46,)"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-     "pack_format": 9,
-     "description": ""
+     "pack_format": 15,
+     "description": "Fog"
   }
 }


### PR DESCRIPTION
- ported the mod to 1.20
- updated fog to be more accurate to how it actually was in the base game (closes #13 and closes #9)
- made night vision remove the fog part of the mod (vanilla also did this when the feature existed)
- added a config option to change the fog distance from the player
- added a config option to blacklist dimensions from rendering void fog/particles, and an option to turn it to a whitelist (closes #12 and closes #9)